### PR TITLE
Frontend Types/Utilities

### DIFF
--- a/src/types/apiRequestBodies.ts
+++ b/src/types/apiRequestBodies.ts
@@ -1,0 +1,122 @@
+/**
+ * If an endpoint request body is not explicitly defined, then it
+ * does not require a request body.
+ */
+
+export interface CreateAttendeeRequest
+{
+	userID: number,
+	eventID: number
+}
+
+export interface CreateEventRequest
+{
+	schoolID: number,
+	address: string,
+	city: string,
+	stateID: number,
+	zip: string
+	rsoID: number,
+	meetingTypeID: number
+	name: string,
+	description: string,
+	room: string,
+	rating: number,
+	isPublic: boolean,
+	numAttendees: number,
+	capacity: number,
+	eventPictures: Array<Buffer>
+}
+
+export interface CreateMeetingTypeRequest
+{
+	name: string
+}
+
+export interface CreateRsoRequest
+{
+	name: string,
+	universityID: number
+}
+
+export interface DeleteAttendeeRequest
+{
+	userID: number,
+	eventID: number
+}
+
+export interface DeleteEventRequest
+{
+	eventID: number
+}
+
+export interface DeleteRsoRequest
+{
+	rsoID: number
+}
+
+export interface GetEventsRequest
+{
+	schoolID: number,
+	rsoID?: number
+}
+
+export interface GetRsoRequest
+{
+	rsoID?: number,
+	name?: string,
+	universityID: number
+}
+
+export interface LoginRequest
+{
+	username: string,
+	password: string
+}
+
+export interface RegisterRequest
+{
+	username: string,
+	password: string,
+	firstname: string,
+	email: string,
+	universityID: number,
+	rsoID: number,
+	role: number,
+	profilePicture?: Buffer
+}
+
+export interface UpdateEventRequest
+{
+	eventID: number,
+	schoolID?: number,
+	stateID?: number,
+	rsoID?: number,
+	meetingType?: number,
+	name?: string,
+	description?: string,
+	address?: string,
+	city?: string,
+	zip?: string,
+	room?: string,
+	isPublic?: boolean,
+	capacity?: number
+}
+
+export interface UpdateRsoRequest
+{
+	rsoID: number,
+	name: string
+}
+
+export interface UpdateUserRequest
+{
+	firstname?: string,
+	lastname?: string,
+	password?: string,
+	email?: string,
+	universityID?: number,
+	rsoID?: number,
+	role?: number,
+	profilePicture?: Buffer
+}

--- a/src/types/apiResponseBodies.ts
+++ b/src/types/apiResponseBodies.ts
@@ -1,0 +1,57 @@
+import { MeetingType, RSO, State } from "./dropDownTypes";
+import { Event } from "./eventTypes";
+import { MysqlError } from "mysql";
+import { UserDataWithoutPassword } from "./userTypes";
+
+/**
+ * Default fields that are always returned with any ApiEndpoint
+ * 
+ * If an endpoint is not explicitly defined in this file, it means
+ * that the endpoint only returns the fields that are in this
+ * default response.
+ */
+export interface DefaultApiResponse
+{
+	readonly success: boolean,
+	readonly error: MysqlError | string
+}
+
+export interface CreateMeetingTypeResponse extends DefaultApiResponse
+{
+	readonly meetingType: MeetingType
+}
+
+export interface CreateRsoReponse extends DefaultApiResponse
+{
+	readonly rsoData: RSO
+}
+
+export interface GetEventResponse extends DefaultApiResponse
+{
+	readonly events: Array<Event>
+}
+
+export interface GetMeetingTypesResponse extends DefaultApiResponse
+{
+	readonly meetingTypes: Array<MeetingType>
+}
+
+export interface GetRsoResponse extends DefaultApiResponse
+{
+	readonly RSOs: Array<RSO>
+}
+
+export interface GetStatesResponse extends DefaultApiResponse
+{
+	readonly states: Array<State>
+}
+
+export interface LoginResponse extends DefaultApiResponse
+{
+	readonly userData: UserDataWithoutPassword
+}
+
+export interface UpdateUserResponse extends DefaultApiResponse
+{
+	readonly newUserData: UserDataWithoutPassword
+}

--- a/src/types/dropDownTypes.ts
+++ b/src/types/dropDownTypes.ts
@@ -1,0 +1,47 @@
+export interface Address
+{
+	streetAddress: string,
+	city: string,
+	state: State,
+	zip: string
+}
+
+export interface Coordinate
+{
+	latitude: string,
+	longitude: string
+}
+
+export interface MeetingType
+{
+	ID: number,
+	name: string
+}
+
+export interface RSO
+{
+	ID: number,
+	name: string,
+	universityID: number
+}
+
+export interface State
+{
+	ID: number,
+	name: string,
+	abbreviation: string
+}
+
+export interface University
+{
+	ID: number,
+	stateID: number,
+	name: string,
+	address: Address,
+	description: string,
+	phoneNumber: string,
+	numStudents: number,
+	email: string,
+	campusPictures: Array<Buffer>,
+	coordinates: Coordinate
+}

--- a/src/types/eventTypes.ts
+++ b/src/types/eventTypes.ts
@@ -1,0 +1,41 @@
+import { University } from "./dropDownTypes";
+
+export interface Event
+{
+	ID: number
+	university: University,
+	address: string,
+	city: string,
+	stateID: string,
+	zip: string,
+	rsoID: number,
+	meetingTypeID: number,
+	name: string,
+	description: string,
+	room: string,
+	rating: number,
+	isPublic: boolean,
+	capacity: number,
+	eventPictures: Array<Buffer>
+}
+
+/**
+ * 
+ */
+export interface NewEvent
+{
+	schoolID: number,
+	address: string,
+	city: string,
+	stateID: string,
+	zip: string,
+	rsoID: number,
+	meetingTypeID: number,
+	name: string,
+	description: string,
+	room: string,
+	rating: number,
+	isPublic: boolean,
+	capacity: number,
+	eventPictures: Array<Buffer>
+}

--- a/src/types/userTypes.ts
+++ b/src/types/userTypes.ts
@@ -1,0 +1,17 @@
+export interface UserDataWithoutPassword
+{
+	ID: number,
+	username: string,
+	firstname: string,
+	lastname: string,
+	email: string,
+	universityID: number,
+	rsoID: number,
+	role: number,
+	profilePicture: Buffer | undefined
+}
+
+export interface UserDataWithPassword extends UserDataWithoutPassword
+{
+	password: string
+}

--- a/src/util/buildpath.ts
+++ b/src/util/buildpath.ts
@@ -1,0 +1,17 @@
+/**
+ * Function to dynamically generate build path with local or remote deployments
+ */
+export default function buildpath(route: string): string
+{
+	if (process.env.NODE_ENV === "production")
+	{
+		// Insert remote base URI here
+
+		// Project did not need to be hosted so there is no existing one
+		return "";
+	}
+	else
+	{
+		return "http://localhost:5000" + route;
+	}
+}


### PR DESCRIPTION
Added some types to provide schemas for the requests/response bodies to send/receive from the API endpoints.

Added some types for data that can be used in multiple locations such as Universities, User Data, etc.

Added a utility script to dynamically construct the build path of the API server to create a seamless runtime environment between local and remote.